### PR TITLE
Update missed reference to the original location

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -24,8 +24,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/bluebreezecf/opentsdb-goclient/client"
-	"github.com/bluebreezecf/opentsdb-goclient/config"
+	"github.com/G-Research/opentsdb-goclient/client"
+	"github.com/G-Research/opentsdb-goclient/config"
 )
 
 func main() {


### PR DESCRIPTION
Not used, but otherwise go.mod ends up with both referenced.