### PR TITLE
Fix return value of ClientContext

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -438,7 +438,7 @@ type ClientContext interface {
 	Client
 }
 
-func NewClientContext(opentsdbCfg config.OpenTSDBConfig) (Client, error) {
+func NewClientContext(opentsdbCfg config.OpenTSDBConfig) (ClientContext, error) {
 	client, err := NewClient(opentsdbCfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
(Now we've forked this we could do away with the complexity of the
two interfaces, but for now I'm just fixing something which I had fixed
in my vendored copy in Geras but not here... oops.)