### PR TITLE
Avoid generating as much garbage

### DIFF
--- a/client/suggest.go
+++ b/client/suggest.go
@@ -65,7 +65,10 @@ func (sugResp *SuggestResponse) SetStatus(code int) {
 
 func (sugResp *SuggestResponse) GetCustomParser() func(respCnt []byte) error {
 	return func(respCnt []byte) error {
-		return json.Unmarshal([]byte(fmt.Sprintf("{%s:%s}", `"ResultInfo"`, string(respCnt))), &sugResp)
+		var results []string
+		err := json.Unmarshal(respCnt, &results)
+		sugResp.ResultInfo = results
+		return err
 	}
 }
 


### PR DESCRIPTION
There's a similar pattern across the library (query.go as well....) but this one hurts because large amounts of metrics result in this string getting copied multiple times in Geras.