### PR TITLE
Add way to stream results of a query over a channel

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -485,7 +485,6 @@ type Response interface {
 // ResponseStream represents a streaming response.
 // TODO: Implement Response in terms of this instead?
 type ResponseStream interface {
-
 	Response
 
 	// HandleBody is given the response.Body. It must call Close on the ReadCloser

--- a/client/client.go
+++ b/client/client.go
@@ -488,9 +488,9 @@ type ResponseStream interface {
 
 	Response
 
-	// HandleBody is given the response.Body. It must call Close on the Reader
+	// HandleBody is given the response.Body. It must call Close on the ReadCloser
 	// when finished (which can be after the method returns).
-	HandleBody(io.Reader) error
+	HandleBody(io.ReadCloser) error
 }
 
 func (c *clientImpl) WithContext(ctx context.Context) Client {

--- a/client/client.go
+++ b/client/client.go
@@ -130,6 +130,11 @@ type Client interface {
 	// is invalid, it failed to parese the response, or OpenTSDB is un-connectable right now.
 	Query(param QueryParam) (*QueryResponse, error)
 
+	// QueryStream is the streaming implementation of 'GET /api/query'.
+	// It will return results over the channel, as they are parsed, resulting in
+	// more predictable memory usage.
+	QueryStream(param QueryParam, outCh chan<- *QueryRespItem) error
+
 	// QueryLast is the implementation of 'GET /api/query/last' endpoint.
 	// It is introduced firstly in v2.1, and fully supported in v2.2. So it should be aware that this api works
 	// well since v2.2 of opentsdb.

--- a/client/client.go
+++ b/client/client.go
@@ -530,7 +530,7 @@ func (c *clientImpl) sendRequest(method, url, reqBodyCnt string, parsedResp Resp
 	case Response:
 		return HandleResponseBody(r, method, url, resp.Body)
 	default:
-		return fmt.Errorf("Unhandled type: %T",  r)
+		return fmt.Errorf("Unhandled type: %T", r)
 	}
 }
 

--- a/client/put.go
+++ b/client/put.go
@@ -60,10 +60,10 @@ func (data *DataPoint) String() string {
 
 // DataPointByTimestamp implements sort.Interface for sorting by timestamp.
 type DataPointByTimestamp []*DataPoint
+
 func (dp DataPointByTimestamp) Len() int           { return len(dp) }
 func (dp DataPointByTimestamp) Swap(i, j int)      { dp[i], dp[j] = dp[j], dp[i] }
 func (dp DataPointByTimestamp) Less(i, j int) bool { return dp[i].Timestamp < dp[j].Timestamp }
-
 
 // PutError holds the error message for each putting DataPoint instance.
 // Only calling PUT() with "details" query parameter, the reponse of

--- a/client/query.go
+++ b/client/query.go
@@ -25,6 +25,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"sort"
 	"strconv"
 )
@@ -224,6 +226,9 @@ type QueryRespItem struct {
 	// the timespan and the results returned in this group.
 	// The value is optional.
 	GlobalAnnotations []Annotation `json:"globalAnnotations,omitempty"`
+
+	// If an error occurred (only used for QueryStream, if the data is malformed while parsing).
+	Error error
 }
 
 // GetDataPoints returns the real ascending datapoints from the information of the related QueryRespItem.
@@ -266,11 +271,8 @@ func (qri *QueryRespItem) GetLatestDataPoint() *DataPoint {
 }
 
 func (c *clientImpl) Query(param QueryParam) (*QueryResponse, error) {
-	if !isValidQueryParam(&param) {
-		return nil, errors.New("The given query param is invalid.\n")
-	}
 	queryEndpoint := fmt.Sprintf("%s%s", c.tsdbEndpoint, QueryPath)
-	reqBodyCnt, err := getQueryBodyContents(&param)
+	reqBodyCnt, err := prepQuery(param)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +283,91 @@ func (c *clientImpl) Query(param QueryParam) (*QueryResponse, error) {
 	return &queryResp, nil
 }
 
-func getQueryBodyContents(param interface{}) (string, error) {
+func (c *clientImpl) QueryStream(param QueryParam, outCh chan<- *QueryRespItem) error  {
+	queryEndpoint := fmt.Sprintf("%s%s", c.tsdbEndpoint, QueryPath)
+	reqBodyCnt, err := prepQuery(param)
+	if err != nil {
+		return err
+	}
+	queryStreamResp := QueryStreamResponse{outCh: outCh}
+	if err = c.sendRequest(PostMethod, queryEndpoint, reqBodyCnt, &queryStreamResp); err != nil {
+		close(outCh)
+		return err
+	}
+	if queryStreamResp.err != nil {
+		close(outCh)
+		return queryStreamResp.err
+	}
+	return nil
+}
+
+type QueryStreamResponse struct {
+	outCh chan<- *QueryRespItem
+	statusCode int
+	err error
+}
+
+func (qs *QueryStreamResponse) GetCustomParser() func(respCnt []byte) error {
+	// unused by ResponseStream
+	return nil
+}
+
+func (qs *QueryStreamResponse) SetStatus(code int) {
+	qs.statusCode = code
+}
+
+func (qs *QueryStreamResponse) String() string {
+	return "[unused]"
+}
+
+func (qs *QueryStreamResponse) HandleBody(body io.ReadCloser) {
+	dec := json.NewDecoder(body)
+	// look at first token, we want a '[' (results) or a '{' (error).
+	t, err := dec.Token()
+	if err != nil {
+		qs.err = err
+		body.Close()
+		return
+	}
+	delim, ok := t.(json.Delim)
+	if !ok || delim != '{' || delim != '[' {
+		qs.err = errors.New("unexpected response format")
+		body.Close()
+		return
+	}
+
+	if delim == '{' {
+		defer body.Close()
+		b, err := ioutil.ReadAll(dec.Buffered())
+		if err != nil {
+			qs.err = err
+		}
+		// XXX: Make a QueryError
+		var m interface{}
+		json.Unmarshal(append([]byte{byte(delim)}, b...), &m)
+		qs.err = errors.New("query error")
+		return
+	}
+
+	go func() {
+		defer body.Close()
+
+		for dec.More() {
+			var m QueryRespItem
+			err := dec.Decode(&m)
+			if err != nil {
+				m.Error = err
+			}
+			qs.outCh <- &m
+		}
+		close(qs.outCh)
+	}()
+}
+
+func prepQuery(param QueryParam) (string, error) {
+	if !isValidQueryParam(&param) {
+		return "", errors.New("The given query param is invalid.\n")
+	}
 	result, err := json.Marshal(param)
 	if err != nil {
 		return "", errors.New(fmt.Sprintf("Failed to marshal query param: %v\n", err))

--- a/client/query.go
+++ b/client/query.go
@@ -283,7 +283,7 @@ func (c *clientImpl) Query(param QueryParam) (*QueryResponse, error) {
 	return &queryResp, nil
 }
 
-func (c *clientImpl) QueryStream(param QueryParam, outCh chan<- *QueryRespItem) error  {
+func (c *clientImpl) QueryStream(param QueryParam, outCh chan<- *QueryRespItem) error {
 	queryEndpoint := fmt.Sprintf("%s%s", c.tsdbEndpoint, QueryPath)
 	reqBodyCnt, err := prepQuery(param)
 	if err != nil {
@@ -298,7 +298,7 @@ func (c *clientImpl) QueryStream(param QueryParam, outCh chan<- *QueryRespItem) 
 }
 
 type QueryStreamResponse struct {
-	outCh chan<- *QueryRespItem
+	outCh      chan<- *QueryRespItem
 	statusCode int
 }
 

--- a/client/query.go
+++ b/client/query.go
@@ -325,7 +325,7 @@ func (qs *QueryStreamResponse) HandleBody(body io.ReadCloser) error {
 	}
 	delim, ok := t.(json.Delim)
 	if !ok || delim != '{' || delim != '[' {
-		return errors.New("unexpected response format")
+		return fmt.Errorf("unexpected response format: %T(%v)", t, t)
 	}
 
 	if delim == '{' {

--- a/client/query.go
+++ b/client/query.go
@@ -324,7 +324,7 @@ func (qs *QueryStreamResponse) HandleBody(body io.ReadCloser) error {
 		return err
 	}
 	delim, ok := t.(json.Delim)
-	if !ok || delim != '{' || delim != '[' {
+	if !ok || (delim != '{' && delim != '[') {
 		return fmt.Errorf("unexpected response format: %T(%v)", t, t)
 	}
 

--- a/client/query.go
+++ b/client/query.go
@@ -312,17 +312,8 @@ type QueryStreamResponse struct {
 	statusCode int
 }
 
-func (qs *QueryStreamResponse) GetCustomParser() func(respCnt []byte) error {
-	// unused by ResponseStream
-	return nil
-}
-
 func (qs *QueryStreamResponse) SetStatus(code int) {
 	qs.statusCode = code
-}
-
-func (qs *QueryStreamResponse) String() string {
-	return "[unused]"
 }
 
 func (qs *QueryStreamResponse) HandleBody(body io.ReadCloser) error {

--- a/client/query_last.go
+++ b/client/query_last.go
@@ -134,10 +134,11 @@ func (c *clientImpl) QueryLast(param QueryLastParam) (*QueryLastResponse, error)
 		return nil, errors.New("The given query param is invalid.\n")
 	}
 	queryEndpoint := fmt.Sprintf("%s%s", c.tsdbEndpoint, QueryLastPath)
-	reqBodyCnt, err := getQueryBodyContents(&param)
+	resultByte, err := json.Marshal(param)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("Failed to marshal query param: %v\n", err))
 	}
+	reqBodyCnt := string(resultByte)
 	queryResp := QueryLastResponse{}
 	if err = c.sendRequest(PostMethod, queryEndpoint, reqBodyCnt, &queryResp); err != nil {
 		return nil, err

--- a/client/suggest.go
+++ b/client/suggest.go
@@ -88,7 +88,6 @@ func (c *clientImpl) Suggest(sugParam SuggestParam) (*SuggestResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(reqBodyCnt)
 	sugResp := SuggestResponse{}
 	if err := c.sendRequest(PostMethod, sugEndpoint, reqBodyCnt, &sugResp); err != nil {
 		return nil, err


### PR DESCRIPTION
This adds `QueryStream` to the client interface.

This only streams each series (i.e. each item in the top level array that OpenTSDB returns), so a large amount of datapoints can still be expensive, but given that will have a relationship to the time window it means it should be possible to bound resource usage in a fairly predictable way.